### PR TITLE
Add activating as pending state for resourceRancherRegistryCredential…

### DIFF
--- a/rancher/resource_rancher_registry_credential.go
+++ b/rancher/resource_rancher_registry_credential.go
@@ -78,7 +78,7 @@ func resourceRancherRegistryCredentialCreate(d *schema.ResourceData, meta interf
 	}
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"active", "removed", "removing"},
+		Pending:    []string{"active", "removed", "removing", "activating"},
 		Target:     []string{"active"},
 		Refresh:    RegistryCredentialStateRefreshFunc(client, newRegistryCredential.Id),
 		Timeout:    10 * time.Minute,


### PR DESCRIPTION
…Create

Added activating as Pending state during rancher registry creation to avoid the next error:
```
Error: Error waiting for registry credential (1c3346130) to be created: unexpected state 'activating', wanted target 'active'. last error: %!s(<nil>)

  on rancher/rancher_environment.tf line 39, in resource \"rancher_registry_credential\" \"quay_credentials\":
  39: resource \"rancher_registry_credential\" \"quay_credentials\" {
```